### PR TITLE
rt_kprintf -> LOG_I

### DIFF
--- a/src/wavplayer.c
+++ b/src/wavplayer.c
@@ -248,10 +248,10 @@ static rt_err_t wavplayer_open(struct wavplayer *player)
     /* read wavfile header information from file */
     wavheader_read(&wav, player->fp);
 
-    LOG_I("Information:\n");
-    LOG_I("samplerate %d\n", wav.fmt_sample_rate);
-    LOG_I("channels %d\n", wav.fmt_channels);
-    LOG_I("sample bits width %d\n", wav.fmt_bit_per_sample);
+    LOG_D("Information:");
+    LOG_D("samplerate %d", wav.fmt_sample_rate);
+    LOG_D("channels %d", wav.fmt_channels);
+    LOG_D("sample bits width %d", wav.fmt_bit_per_sample);
 
     /* set sampletate,channels, samplebits */
     caps.main_type = AUDIO_TYPE_OUTPUT;

--- a/src/wavplayer.c
+++ b/src/wavplayer.c
@@ -248,10 +248,10 @@ static rt_err_t wavplayer_open(struct wavplayer *player)
     /* read wavfile header information from file */
     wavheader_read(&wav, player->fp);
 
-    rt_kprintf("Information:\n");
-    rt_kprintf("samplerate %d\n", wav.fmt_sample_rate);
-    rt_kprintf("channels %d\n", wav.fmt_channels);
-    rt_kprintf("sample bits width %d\n", wav.fmt_bit_per_sample);
+    LOG_I("Information:\n");
+    LOG_I("samplerate %d\n", wav.fmt_sample_rate);
+    LOG_I("channels %d\n", wav.fmt_channels);
+    LOG_I("sample bits width %d\n", wav.fmt_bit_per_sample);
 
     /* set sampletate,channels, samplebits */
     caps.main_type = AUDIO_TYPE_OUTPUT;


### PR DESCRIPTION
建议rt_kprintf 换成 LOG_I 统一控制输出信息