### PR TITLE
[update]解决fmt_bit_per_sample = 16 代码位置错误，支持samplerate 192000 .

### DIFF
--- a/src/wavhdr.c
+++ b/src/wavhdr.c
@@ -81,9 +81,9 @@ int wavheader_init(struct wav_header *header, int sample_rate, int channels, int
     header->fmt_compression_code = 1;
     header->fmt_channels = channels;
     header->fmt_sample_rate = sample_rate;
+    header->fmt_bit_per_sample = 16;
     header->fmt_avg_bytes_per_sec = header->fmt_sample_rate * header->fmt_channels * header->fmt_bit_per_sample / 8;
     header->fmt_block_align = header->fmt_bit_per_sample * header->fmt_channels / 8;
-    header->fmt_bit_per_sample = 16;
 
     memcpy(header->data_id, "data", 4);
     header->data_datasize = datasize;

--- a/src/wavrecorder_cmd.c
+++ b/src/wavrecorder_cmd.c
@@ -23,7 +23,7 @@ struct wavrecord_args
 {
     int action;
     char *file;
-    rt_uint16_t samplerate;
+    rt_uint32_t samplerate;
     rt_uint16_t channels;
     rt_uint16_t samplebits;
 };


### PR DESCRIPTION
修复fmt_bit_per_sample = 16 代码位置错误，支持samplerate 192000 .