### PR TITLE
After rt-thread V5.0,api rt_mq_recv changed the return parameter

### DIFF
--- a/src/wavplayer.c
+++ b/src/wavplayer.c
@@ -315,7 +315,7 @@ static int wavplayer_event_handler(struct wavplayer *player, int timeout)
 #endif
 
     result = rt_mq_recv(player->mq, &msg, sizeof(struct play_msg), timeout);
-    #if RT_VERSION_CHECK(RT_VERSION_MAJOR,RT_VERSION_MINOR,RT_VERSION_PATCH) > 50000
+    #if RT_VER_NUM > 0x50000
     if (!result)
     #else
     if (RT_EOK != result)

--- a/src/wavplayer.c
+++ b/src/wavplayer.c
@@ -315,7 +315,11 @@ static int wavplayer_event_handler(struct wavplayer *player, int timeout)
 #endif
 
     result = rt_mq_recv(player->mq, &msg, sizeof(struct play_msg), timeout);
-    if (result != RT_EOK)
+    #if RT_VERSION_CHECK(RT_VERSION_MAJOR,RT_VERSION_MINOR,RT_VERSION_PATCH) > 50000
+    if (!result)
+    #else
+    if (RT_EOK != result)
+    #endif
     {
         event = PLAYER_EVENT_NONE;
         return event;


### PR DESCRIPTION
修复rt_mq_recv 返回参数的修改后，导致无法播放的问题，兼容V5.0以上的版本