### PR TITLE
兼容rt-thread5.0以上版本，rt_mq_recv返回值的问题

### DIFF
--- a/src/wavplayer.c
+++ b/src/wavplayer.c
@@ -315,7 +315,11 @@ static int wavplayer_event_handler(struct wavplayer *player, int timeout)
 #endif
 
     result = rt_mq_recv(player->mq, &msg, sizeof(struct play_msg), timeout);
-    if (result != RT_EOK)
+    #if RT_VER_NUM > 0x50000
+    if (!result)
+    #else
+    if (RT_EOK != result)
+    #endif
     {
         event = PLAYER_EVENT_NONE;
         return event;


### PR DESCRIPTION
使用RT_VER_NUM宏，兼容rt-thread5.0以上版本。